### PR TITLE
use virtual module prefix to play nice with other plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "mocha": "^2.4.5",
     "rimraf": "^2.5.4",
     "rollup": "^0.25.4",
-    "rollup-plugin-babel": "^2.4.0"
+    "rollup-plugin-babel": "^2.4.0",
+    "rollup-plugin-node-resolve": "^2.0.0"
   },
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -27,8 +27,8 @@ var _mods2 = {
   process: PROCESS_PATH,
   Buffer: [BUFFER_PATH, 'Buffer'],
   global: GLOBAL_PATH,
-  __filename: '__filename',
-  __dirname: '__dirname'
+  __filename: '\0__filename',
+  __dirname: '\0__dirname'
 };
 var mods1 = new Map();
 var mods2 = new Map();
@@ -60,12 +60,12 @@ export default options => {
       }
     },
     resolveId(importee, importer) {
-      if (importee === '__dirname') {
+      if (importee === '\0__dirname') {
         let id = randomBytes(15).toString('hex');
         dirs.set(id, dirname('/' + relative(basedir, importer)));
         return id;
       }
-      if (importee === '__filename') {
+      if (importee === '\0__filename') {
         let id = randomBytes(15).toString('hex');
         dirs.set(id, '/' + relative(basedir, importer));
         return id;

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,6 @@
 
 var rollup = require( 'rollup' );
+var nodeResolve = require( 'rollup-plugin-node-resolve' );
 var globals = require( '../dist/rollup-plugin-node-globals.cjs' );
 var path = require('path');
 var vm = require('vm');
@@ -44,4 +45,26 @@ describe( 'rollup-plugin-node-globals', function () {
 		});
 	});
 })
+
+  it( 'works with rollup-plugin-node-resolve', function () {
+    return rollup.rollup({
+      entry: 'test/examples/dirname.js',
+      plugins: [
+        nodeResolve(),
+        globals()
+      ]
+    }).then( function ( bundle ) {
+      var generated = bundle.generate();
+      var code = generated.code;
+      var script = new vm.Script(code);
+      var context = vm.createContext({
+        dirname: path.join(__dirname, 'examples'),
+        filename: path.join(__dirname, 'examples', 'dirname.js'),
+        setTimeout: setTimeout,
+        clearTimeout: clearTimeout,
+      });
+      context.self = context;
+      script.runInContext(context);
+    });
+  });
 });


### PR DESCRIPTION
Notwithstanding our separate conversations about consolidating some of the `node-` plugins, I just ran into an issue while trying to fix https://github.com/rollup/rollup-plugin-commonjs/issues/90, which is that other plugins might try to resolve IDs like `__filename` depending on the plugin order (and in the case of rollup-plugin-node-resolve, that blows up).

The 'convention' (albeit not very well documented etc) with other plugins that use virtual modules is to prefix module IDs with `\0`, or even `\0mypluginname:` – this prevents other plugins from trying to resolve those IDs (the logic is built into `createFilter`, for example). `\0` works because it's not a legal character in file names.