### PR TITLE
fix(): begin using acorn provided by rollup.

### DIFF
--- a/dist/rollup-plugin-node-globals.cjs.js
+++ b/dist/rollup-plugin-node-globals.cjs.js
@@ -4,7 +4,6 @@ function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'defau
 
 var rollupPluginutils = require('rollup-pluginutils');
 var estreeWalker = require('estree-walker');
-var acorn = require('acorn');
 var MagicString = _interopDefault(require('magic-string'));
 var path = require('path');
 var crypto = require('crypto');
@@ -67,11 +66,11 @@ function flatten(node) {
   };
 }
 
-function inject (code, id, mod1, mod2, sourceMap) {
+function inject (code, id, mod1, mod2, sourceMap, parse) {
   var ast = void 0;
 
   try {
-    ast = acorn.parse(code, {
+    ast = parse(code, {
       ecmaVersion: 8,
       sourceType: 'module'
     });
@@ -245,13 +244,13 @@ var index = (function (options) {
     },
     transform: function transform(code, id) {
       if (id === BUFFER_PATH) {
-        return inject(code, id, buf, new Map(), sourceMap);
+        return inject(code, id, buf, new Map(), sourceMap, this.parse);
       }
       if (!filter(id)) return null;
       if (code.search(firstpass) === -1) return null;
       if (id.slice(-3) !== '.js') return null;
 
-      var out = inject(code, id, mods1, mods2, sourceMap);
+      var out = inject(code, id, mods1, mods2, sourceMap, this.parse);
       return out;
     }
   };

--- a/dist/rollup-plugin-node-globals.es6.js
+++ b/dist/rollup-plugin-node-globals.es6.js
@@ -1,6 +1,5 @@
 import { attachScopes, createFilter } from 'rollup-pluginutils';
 import { walk } from 'estree-walker';
-import { parse } from 'acorn';
 import MagicString from 'magic-string';
 import { join, relative, dirname } from 'path';
 import { randomBytes } from 'crypto';
@@ -63,7 +62,7 @@ function flatten(node) {
   };
 }
 
-function inject (code, id, mod1, mod2, sourceMap) {
+function inject (code, id, mod1, mod2, sourceMap, parse) {
   var ast = void 0;
 
   try {
@@ -241,13 +240,13 @@ var index = (function (options) {
     },
     transform: function transform(code, id) {
       if (id === BUFFER_PATH) {
-        return inject(code, id, buf, new Map(), sourceMap);
+        return inject(code, id, buf, new Map(), sourceMap, this.parse);
       }
       if (!filter(id)) return null;
       if (code.search(firstpass) === -1) return null;
       if (id.slice(-3) !== '.js') return null;
 
-      var out = inject(code, id, mods1, mods2, sourceMap);
+      var out = inject(code, id, mods1, mods2, sourceMap, this.parse);
       return out;
     }
   };

--- a/package.json
+++ b/package.json
@@ -18,12 +18,11 @@
   "author": "Calvin Metcalf <calvin.metcalf@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "acorn": "^5.5.0",
     "buffer-es6": "^4.9.3",
     "estree-walker": "^0.5.1",
-    "magic-string": "^0.22.4",
+    "magic-string": "^0.25.0",
     "process-es6": "^0.11.6",
-    "rollup-pluginutils": "^2.0.1"
+    "rollup-pluginutils": "^2.3.1"
   },
   "keywords": [
     "rollup-plugin"
@@ -35,9 +34,9 @@
     "mkdirp": "^0.5.1",
     "mocha": "^5.0.1",
     "rimraf": "^2.6.2",
-    "rollup": "^0.56.3",
+    "rollup": "^0.64.1",
     "rollup-plugin-babel": "^3.0.3",
-    "rollup-plugin-node-resolve": "^3.0.3"
+    "rollup-plugin-node-resolve": "^3.3.0"
   },
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -76,13 +76,13 @@ export default options => {
     },
     transform(code, id) {
       if (id === BUFFER_PATH) {
-        return inject(code, id, buf, new Map(), sourceMap);
+        return inject(code, id, buf, new Map(), sourceMap, this.parse);
       }
       if (!filter(id)) return null;
       if (code.search(firstpass) === -1) return null;
       if (id.slice(-3) !== '.js') return null;
 
-      var out = inject(code, id, mods1, mods2, sourceMap);
+      var out = inject(code, id, mods1, mods2, sourceMap, this.parse);
       return out;
     }
   }

--- a/src/inject/index.js
+++ b/src/inject/index.js
@@ -4,9 +4,6 @@ import {
 import {
   walk
 } from 'estree-walker';
-import {
-  parse
-} from 'acorn';
 import makeLegalIdentifier from './makeLegalIdentifier';
 import MagicString from 'magic-string';
 
@@ -51,7 +48,7 @@ function flatten(node) {
 }
 
 
-export default function(code, id, mod1, mod2, sourceMap) {
+export default function(code, id, mod1, mod2, sourceMap, parse) {
   let ast;
 
   try {


### PR DESCRIPTION
Rollup provides its own instance of acorn.  Using the provided version of acorn will allow dynamic imports to be parsed correctly.

This pull request fixes issue #14.