### PR TITLE
feat: upgrade ecmaVersion to 9

### DIFF
--- a/src/inject/index.js
+++ b/src/inject/index.js
@@ -56,7 +56,7 @@ export default function(code, id, mod1, mod2, sourceMap) {
 
   try {
     ast = parse(code, {
-      ecmaVersion: 8,
+      ecmaVersion: 9,
       sourceType: 'module'
     });
   } catch (err) {

--- a/test/fixtures/process-browser.js
+++ b/test/fixtures/process-browser.js
@@ -1,3 +1,7 @@
+// Special case for spread operator
+const a = {};
+const b = {...a};
+
 if (!process.browser) {
   throw Error('must be a browser');
 }


### PR DESCRIPTION
Hello,

I'm currently working on a migration from browserify to rollup on a big project, and I encountered a problem with a syntax error when using `...` (spread operator).

I added a small test case:
![capture d ecran de 2018-08-30 08-05-03](https://user-images.githubusercontent.com/2103975/44832742-0c516700-ac2c-11e8-8694-d2b680047016.png)

After upgrading [`ecmaVersion` to 9](https://github.com/acornjs/acorn/issues/664), this works great:

![capture d ecran de 2018-08-30 08-10-36](https://user-images.githubusercontent.com/2103975/44832790-33a83400-ac2c-11e8-8e6d-f81d932cd6a5.png)

Anyway, I think that would be nicer if you can give the user some options to configure `ecmaVersion`, no?