### PR TITLE
chore: update acorn to v7.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "Calvin Metcalf <calvin.metcalf@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "acorn": "^5.7.3",
+    "acorn": "^7.0.0",
     "buffer-es6": "^4.9.3",
     "estree-walker": "^0.5.2",
     "magic-string": "^0.22.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -59,9 +59,14 @@ acorn-node@^1.2.0, acorn-node@^1.3.0, acorn-node@^1.5.2:
     acorn-dynamic-import "^3.0.0"
     xtend "^4.0.1"
 
-acorn@^5.0.0, acorn@^5.5.3, acorn@^5.7.1, acorn@^5.7.3:
+acorn@^5.0.0, acorn@^5.5.3, acorn@^5.7.1:
   version "5.7.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
+
+acorn@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.0.tgz#949d36f2c292535da602283586c2477c57eb2d6c"
+  integrity sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==
 
 ajv@^5.3.0:
   version "5.5.2"


### PR DESCRIPTION
This PR bumps `acorn` to v7.0.0 so that it can support parsing the optional catch binding introduced in ES2019.